### PR TITLE
fix send msg bug

### DIFF
--- a/include/libApexArinc653/CQueuing.h
+++ b/include/libApexArinc653/CQueuing.h
@@ -8,7 +8,7 @@
 
 #define MSG_LENGTH 1000
 
-int SEND_QUEUING_MESSAGE(char *name, int portId, int sock, char *emetteur, char *message);
+int SEND_QUEUING_MESSAGE(char *name, int portId, int sock, char *emetteur, char *message, int msgLen);
 int RECEIVE_QUEUING_MESSAGE(int sock, Type_Message *rMessage);
 
 #endif

--- a/include/libApexArinc653/CSampling.h
+++ b/include/libApexArinc653/CSampling.h
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include "CCommunication.h"
 
-int WRITE_SAMPLING_MESSAGE(char *name, int portId, int sock, char *emetteur, char *message);
+int WRITE_SAMPLING_MESSAGE(char *name, int portId, int sock, char *emetteur, char *message, int msgLen);
 int READ_SAMPLING_MESSAGE(int sock, Type_Message *rMessage);
 
 #endif

--- a/sources/UseCases/BEI_AGILE/Capteur/capteur.cpp
+++ b/sources/UseCases/BEI_AGILE/Capteur/capteur.cpp
@@ -43,13 +43,13 @@ int main(int argc, char *argv[]) {
         sprintf(sMessage, "message capteur numero %d", j); // message à evoyer
         std::cout << "			" << std::endl;
         std::cout << ">>> Sending message: " << sMessage << std::endl;
-        SEND_QUEUING_MESSAGE(name_machine, portID0, sock0, myCvector.emetteur, sMessage);
+        SEND_QUEUING_MESSAGE(name_machine, portID0, sock0, myCvector.emetteur, sMessage, strlen(sMessage));
         j++;
 
         sprintf(sMessage, "message capteur numero %d", j); // message à evoyer
         std::cout << "			" << std::endl;
         std::cout << ">>> Sending message: " << sMessage << std::endl;
-        SEND_QUEUING_MESSAGE(name_machine, portID1, sock1, myCvector.emetteur, sMessage);
+        SEND_QUEUING_MESSAGE(name_machine, portID1, sock1, myCvector.emetteur, sMessage, strlen(sMessage));
         j++;
 
 

--- a/sources/UseCases/BEI_AGILE/Primary/primary.cpp
+++ b/sources/UseCases/BEI_AGILE/Primary/primary.cpp
@@ -38,14 +38,14 @@ int main(int argc, char *argv[]) {
         sprintf(sMessage, "QMessage envoye depuis Primary numero %d", j);
         std::cout << "			" << std::endl;
         std::cout << ">>> Sending message: " << sMessage << std::endl;
-        SEND_QUEUING_MESSAGE(name_machine, portIDQ1, sockQ1, myCvector.emetteur, sMessage);
+        SEND_QUEUING_MESSAGE(name_machine, portIDQ1, sockQ1, myCvector.emetteur, sMessage, strlen(sMessage));
         j++;
         std::cout << "Queuing message sent: " << sMessage << std::endl;
 
         sprintf(sMessage, "SMessage from primary #%d", j);
         std::cout << "			" << std::endl;
         std::cout << ">>> Sending message: " << sMessage << std::endl;
-        ret = WRITE_SAMPLING_MESSAGE(name_machine, portIDS0, sockS0, myCvector.emetteur, sMessage);
+        ret = WRITE_SAMPLING_MESSAGE(name_machine, portIDS0, sockS0, myCvector.emetteur, sMessage, strlen(sMessage));
         if (ret == -1) {
             perror("WRITE_SAMPLING_MESSAGE : ");
         }

--- a/sources/UseCases/JNI_Queuing/f2/function2.cpp
+++ b/sources/UseCases/JNI_Queuing/f2/function2.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]) {
             char sMessage[256];
             std::cout << "Sending queuing message numero " << ifmessage << std::endl;
             sprintf(sMessage, "Message envoye depuis f2 numero %d", ifmessage);
-            SEND_QUEUING_MESSAGE(argv[0], portID, sock, myCvector.emetteur, sMessage);
+            SEND_QUEUING_MESSAGE(argv[0], portID, sock, myCvector.emetteur, sMessage, strlen(sMessage));
     }
     for (;;) {
        // std::cout << "debur boucle for, vqueuing_socket[0] : " << sock << std::endl;

--- a/sources/UseCases/JNI_Sampling/f2/function2.cpp
+++ b/sources/UseCases/JNI_Sampling/f2/function2.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]) {
             char sMessage[256];
             std::cout << "Sending sampling message numero " << ifmessage << std::endl;
             sprintf(sMessage, "Message envoye depuis f2 numero %d", ifmessage);
-            WRITE_SAMPLING_MESSAGE(argv[0], portID, sock, myCvector.emetteur, sMessage);
+            WRITE_SAMPLING_MESSAGE(argv[0], portID, sock, myCvector.emetteur, sMessage, strlen(sMessage));
     }
     for (;;) {
        // std::cout << "debur boucle for, vqueuing_socket[0] : " << sock << std::endl;

--- a/sources/UseCases/Queueing/f1/function1.cpp
+++ b/sources/UseCases/Queueing/f1/function1.cpp
@@ -9,7 +9,7 @@
 int main(int argc, char *argv[]) {
     int redemarrage = atoi(argv[7]);
     int position = atoi(argv[6]);
-    GUI_ARINC_partition("Partition1", position, redemarrage);
+	GUI_ARINC_partition("Partition1", position, redemarrage);
     std::cout << "GUI OK" << std::endl;
     Type_Message rMessage;
     int nbarg = argc;
@@ -33,13 +33,28 @@ int main(int argc, char *argv[]) {
     vector_get(&(myCvector.vqueuing_port), 0, &portID);
     vector_get(&(myCvector.vqueuing_socket), 0, &sock);
 
+    sleep(2);
+
+    char sMessage[256];
+    sprintf(sMessage, "P1 INIT_DONE");
+    SEND_QUEUING_MESSAGE(argv[0], portID, sock, myCvector.emetteur, sMessage, 256);
+
+    int msgID = 0;
+    int msgNum = 0;
+
     for (;;) {
-        char sMessage[256];
-        sprintf(sMessage, "Message envoye depuis f1 numero %d", j);
-        std::cout << "			" << std::endl;
-        std::cout << ">>> Sending message: " << sMessage << std::endl;
-        SEND_QUEUING_MESSAGE(argv[0], portID, sock, myCvector.emetteur, sMessage);
-        j++;
+
+
+
+    	memcpy(sMessage, &msgID, 4);
+    	memcpy(sMessage+4, &msgNum, 4);
+		SEND_QUEUING_MESSAGE(argv[0], portID, sock, myCvector.emetteur, sMessage, 256);
+
+        std::cout << ">>> Sending message: " << msgNum << std::endl;
+
+		msgNum++;
+
+
 
         ifmsg = RECEIVE_QUEUING_MESSAGE(sock, &rMessage);
         if (ifmsg > 0) {
@@ -47,7 +62,7 @@ int main(int argc, char *argv[]) {
             std::cout << "<<< Receiving message from: " << rMessage.m_sender << " - Length: " << rMessage.m_length << std::endl;
             std::cout << "<<< Message: " << rMessage.m_message << std::endl;
         } else {
-            std::cout << "<<< No new message" << std::endl;
+            //std::cout << "<<< No new message" << std::endl;
         }
 
         sleep(1);

--- a/sources/UseCases/Queueing/f2/function2.cpp
+++ b/sources/UseCases/Queueing/f2/function2.cpp
@@ -6,7 +6,7 @@
 int main(int argc, char *argv[]) {
     int redemarrage = atoi(argv[7]);
     int position = atoi(argv[6]);
-    GUI_ARINC_partition("Partition2", position, redemarrage);
+	GUI_ARINC_partition("Partition2", position, redemarrage);
     int nbarg = argc;
     char **argument = new char*[argc];
     int i = 0;
@@ -24,24 +24,36 @@ int main(int argc, char *argv[]) {
     int ifmsg = 0;
     int j = 0;
 
+    while(RECEIVE_QUEUING_MESSAGE(sock, &rMessage) <= 0) {
+        ;
+    }
+
+    if(strcmp(rMessage.m_message,"P1 INIT_DONE") == 0) {
+        printf("P2 Beginning of command loop... \n");
+    } else {
+        printf("p2 failed : Received %s from P1\n", rMessage.m_message);
+        return 0;
+    }
+    int msgID = 0;
+    int msgCnt = 0;
     for (;;) {
+        if(RECEIVE_QUEUING_MESSAGE(sock, &rMessage)>0)
+        {
+            memcpy(&msgID, rMessage.m_message, 4);
+            memcpy(&msgCnt, rMessage.m_message+4, 4);
+            std::cout << "<<< recv msgID: " << msgID << " msgCnt:" << msgCnt <<std::endl;
+        }
+
+        /*
         char sMessage[256];
         sprintf(sMessage, "Message envoye depuis f2 numero %d", j);
         std::cout << "			" << std::endl;
         std::cout << ">>> Sending message: " << sMessage << std::endl;
         SEND_QUEUING_MESSAGE(argv[0], portID, sock, myCvector.emetteur, sMessage);
         j++;
-        std::cout << "Queuing message sent: " << sMessage << std::endl;
+        std::cout << "Queuing message sent: " << sMessage << std::endl;*/
         
-        ifmsg = RECEIVE_QUEUING_MESSAGE(sock, &rMessage);
-        if (ifmsg > 0) {
-            std::cout << "			" << std::endl;
-            std::cout << "<<< Receiving message from: " << rMessage.m_sender << " - Length: " << rMessage.m_length << std::endl;
-            std::cout << "<<< Message: " << rMessage.m_message << std::endl;
-        }else{
-            std::cout << "No new message" << std::endl;
-        }
-        
+       
         sleep(1);
     }
     return 0;

--- a/sources/UseCases/Sampling/f1/function1.cpp
+++ b/sources/UseCases/Sampling/f1/function1.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
         sprintf(sMessage, "message envoye depuis Part1 numero %d", i);
         std::cout << "			" << std::endl;
         std::cout << ">>> Sending message: " << sMessage << std::endl;
-        ret = WRITE_SAMPLING_MESSAGE(name_machine, samp_port, samp_socket, myCvector.emetteur, sMessage);
+        ret = WRITE_SAMPLING_MESSAGE(name_machine, samp_port, samp_socket, myCvector.emetteur, sMessage, strlen(sMessage));
 
         if (ret == -1) {
             perror("WRITE_SAMPLING_MESSAGE : ");

--- a/sources/UseCases/Sampling/f2/function2.cpp
+++ b/sources/UseCases/Sampling/f2/function2.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
         std::cout << "			" << std::endl;
         std::cout << ">>> Sending message: " << sMessage << std::endl;
 
-        WRITE_SAMPLING_MESSAGE(name_machine, samp_port, samp_socket, myCvector.emetteur, sMessage);
+        WRITE_SAMPLING_MESSAGE(name_machine, samp_port, samp_socket, myCvector.emetteur, sMessage, strlen(sMessage));
 
         ret = READ_SAMPLING_MESSAGE(samp_socket, rMessage);
 

--- a/sources/UseCases/multimachine/f3/function3.cpp
+++ b/sources/UseCases/multimachine/f3/function3.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[]) {
     for (;;) {
         i++;
         sprintf(result, "marthym f3 sampling message numero %d", i);
-        Sservice.WRITE_SAMPLING_MESSAGE(machine_name, myCvector.vsamp_port[0], myCvector.vsamp_socket[0], myCvector.emetteur, result);
+        Sservice.WRITE_SAMPLING_MESSAGE(machine_name, myCvector.vsamp_port[0], myCvector.vsamp_socket[0], myCvector.emetteur, result, strlen(result));
 
         Sservice.READ_SAMPLING_MESSAGE(myCvector.vsamp_socket[0]);
         Sservice.Display_Message();

--- a/sources/UseCases/multimachine/f4/function4.cpp
+++ b/sources/UseCases/multimachine/f4/function4.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[]) {
     for (;;) {
         i++;
         sprintf(result, "marthym f4 : sampling message numero %d", i);
-        Sservice.WRITE_SAMPLING_MESSAGE(machine_name, myCvector.vsamp_port[0], myCvector.vsamp_socket[0], myCvector.emetteur, result);
+        Sservice.WRITE_SAMPLING_MESSAGE(machine_name, myCvector.vsamp_port[0], myCvector.vsamp_socket[0], myCvector.emetteur, result, strlen(result));
 
         Sservice.READ_SAMPLING_MESSAGE(myCvector.vsamp_socket[0]);
         Sservice.Display_Message();

--- a/sources/UseCases/petshop/f2/function2.cpp
+++ b/sources/UseCases/petshop/f2/function2.cpp
@@ -60,8 +60,8 @@ int main(int argc, char *argv[]) {
         sprintf(sMessage, "Message sent from Partition2 number: %d", j);
         std::cout << "			" << std::endl;
         std::cout << ">>> Sending message: " << sMessage << std::endl;
-        SEND_QUEUING_MESSAGE(name, queuingPortID, queuingSock, emetteur, rMessage.m_message);
-        WRITE_SAMPLING_MESSAGE(name, samplingPortID, samplingSock, emetteur, rMessage.m_message);
+        SEND_QUEUING_MESSAGE(name, queuingPortID, queuingSock, emetteur, rMessage.m_message, rMessage.m_length);
+        WRITE_SAMPLING_MESSAGE(name, samplingPortID, samplingSock, emetteur, rMessage.m_message, rMessage.m_length);
         j++;
         
         sleep(4);

--- a/sources/libApexArinc653/CQueuing.c
+++ b/sources/libApexArinc653/CQueuing.c
@@ -66,12 +66,17 @@ typedef int  int RETURN_CODE_TYPE;*/
  * @param message
  * @return 
  */
-int SEND_QUEUING_MESSAGE(char *name, int portId, int sock, char *emetteur, char *message) {
+int SEND_QUEUING_MESSAGE(char *name, int portId, int sock, char *emetteur, char *message, int msgLen) {
 
     const char *str1 = message; //convert char to const char
     Type_Message myMessage;
-    strcpy(myMessage.m_message, str1);
-    myMessage.m_length = sizeof (myMessage.m_message);
+    if (msgLen > MSG_LENGTH || msgLen <= 0)
+    {
+        perror("message lenght error");
+        return -1;
+    }
+    memcpy(myMessage.m_message, str1, msgLen);
+    myMessage.m_length = msgLen;
     const char *str2 = emetteur;
     strcpy(myMessage.m_sender, str2);
 

--- a/sources/libApexArinc653/CSampling.c
+++ b/sources/libApexArinc653/CSampling.c
@@ -8,11 +8,18 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-int WRITE_SAMPLING_MESSAGE(char *name, int portId, int sock, char *emetteur, char *message) {
+int WRITE_SAMPLING_MESSAGE(char *name, int portId, int sock, char *emetteur, char *message, int msgLen) {
     const char *str1 = message; //convert char to const char    
     Type_Message myMessage;
-    strcpy(myMessage.m_message, str1);
-    myMessage.m_length = sizeof (myMessage.m_message);
+
+    if (msgLen > MSG_LENGTH || msgLen <= 0)
+    {
+        perror("message length error");
+        return -1;
+    }
+    memcpy(myMessage.m_message, str1, msgLen);
+    myMessage.m_length = msgLen;
+
     const char *str2 = emetteur;
     strcpy(myMessage.m_sender, str2);
 


### PR DESCRIPTION
Hello, Martin! I graduated from ENSEEIHT last year.  I met you at IRIT with my classmates, and  used your ARINC653 simulator in our ITP project (https://github.com/oneWayOut/ArDroneARINC653) last year. Thank you!
During our project,  as we want to put some integer to the message buffer, we found a bug and  change the simulator a little bit. In SEND_QUEUING_MESSAGE and WRITE_SAMPLING_MESSAGE functions, they use strcpy, if we want to send a message which is not a string, for instance send a int value 1; because the first byte of int 1 is zero, strcpy will copy nothing to the message buffer. That would be a proplem. 